### PR TITLE
update versions, parameters, and Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 pkg/
 wasm-pack.log
 gh-pages
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ minijinja = { version = "1.0.0", features = ["loader", "json", "urlencode", "pre
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 serde_json = "1.0.91"
-serde-wasm-bindgen = "0.4.5"
+serde-wasm-bindgen = "0.6.1"
 serde = { version = "1.0.152", features = ["derive"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # MiniJinja Sandbox
 
 This repository contains a small WASM project to demo MiniJinja in the browser.
+
+### Setup
+1. [Install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+2. Run
+```bash
+   wasm-pack build
+   cd www
+   npm install
+   npm run start
+   ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn convert_instructions<'a, 'source>(
 
 #[wasm_bindgen]
 pub fn instructions(template: &str) -> Result<JsValue, JsError> {
-    let tmpl = machinery::CompiledTemplate::new("<string>", template, Default::default())
+    let tmpl = machinery::CompiledTemplate::new("<string>", template, Default::default(), true)
         .map_err(annotate_error)?;
     let mut all = BTreeMap::new();
     all.insert("<root>", convert_instructions(&tmpl.instructions));

--- a/www/app.jsx
+++ b/www/app.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import * as wasm from "minijinja-playground";
 
 import AceEditor from "react-ace";

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,13 +1,10 @@
 {
-  "name": "create-wasm-app",
+  "name": "www",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "create-wasm-app",
-      "version": "0.1.0",
-      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "ace-builds": "^1.14.0",
         "minijinja-playground": "file:../pkg",


### PR DESCRIPTION
- Updated serde-wasm-bindgen version to the most recent 0.6.1
- Included a missing boolean parameter in the `machinery::CompiledTemplate::new` initializer that was breaking
- updated the README with a bit more details on setup